### PR TITLE
Implement onboarding keyboard and router setup

### DIFF
--- a/main.py
+++ b/main.py
@@ -10,9 +10,12 @@ from handlers.backpack import backpack_router
 from handlers.combination import combination_router
 from handlers.vip_access import vip_router
 from handlers.notifications import notifications_router
+from handlers.gamification import gamification_router
+from handlers.admin import admin_router
 from middlewares.logging import LoggingMiddleware
 from middlewares.vip_middleware import VIPMiddleware
 from utils.notification_scheduler import notification_scheduler
+from utils.helpers import get_onboarding_keyboard
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
@@ -27,10 +30,15 @@ dp.include_router(backpack_router)
 dp.include_router(combination_router)
 dp.include_router(vip_router)
 dp.include_router(notifications_router)
+dp.include_router(gamification_router)
+dp.include_router(admin_router)
 
 @dp.message(CommandStart())
 async def start_command(message: Message):
-    await message.answer("El sistema está activo. Usa los botones para navegar.")
+    await message.answer(
+        "El sistema está activo. ¿Qué te gustaría hacer?",
+        reply_markup=get_onboarding_keyboard()
+    )
 
 async def main():
     scheduler_task = asyncio.create_task(notification_scheduler(bot))

--- a/utils/helpers.py
+++ b/utils/helpers.py
@@ -8,7 +8,10 @@ def get_onboarding_keyboard():
     from aiogram.types import ReplyKeyboardMarkup, KeyboardButton
 
     keyboard = [
-        [KeyboardButton(text="👜 Abrir mi colección miserable")]
+        [KeyboardButton(text="✨ Conocer a Diana")],
+        [KeyboardButton(text="👜 Abrir mi colección miserable")],
+        [KeyboardButton(text="🎯 Misiones Diarias")],
+        [KeyboardButton(text="🎁 Reclamar Recompensa Diaria")]
     ]
     return ReplyKeyboardMarkup(keyboard=keyboard, resize_keyboard=True)
 


### PR DESCRIPTION
## Summary
- connect missing routers in `main.py`
- update `/start` to show onboarding keyboard
- define full onboarding keyboard in `utils.helpers`

## Testing
- `python -m pip install -r requirements.txt` *(fails: build wheel for aiohttp)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6867364fc2f8832994cead9716d7176f