### PR TITLE
Use BigInteger for user and session IDs

### DIFF
--- a/core/database.py
+++ b/core/database.py
@@ -38,3 +38,9 @@ def init_db():
     Base.metadata.create_all(bind=engine)
     print("✅ Base de datos inicializada correctamente")
     print("📊 Tablas creadas: users, missions, user_missions, game_sessions, game_leaderboards")
+
+def reset_db():
+    """Resetea la base de datos (solo para desarrollo)"""
+    Base.metadata.drop_all(bind=engine)
+    Base.metadata.create_all(bind=engine)
+    print("\ud83d\udd04 Base de datos reseteada")

--- a/models/game_session.py
+++ b/models/game_session.py
@@ -1,11 +1,11 @@
-from sqlalchemy import Column, Integer, String, Boolean, ForeignKey, Text, Float
+from sqlalchemy import Column, Integer, String, Boolean, ForeignKey, Text, Float, BigInteger
 from sqlalchemy.orm import relationship
 from .base import BaseModel
 
 class GameSession(BaseModel):
     __tablename__ = 'game_sessions'
     
-    user_id = Column(Integer, ForeignKey('users.id'), nullable=False)
+    user_id = Column(BigInteger, ForeignKey('users.id'), nullable=False)
     game_type = Column(String(50), nullable=False)
     status = Column(String(20), default='active')
     score = Column(Integer, default=0)
@@ -22,7 +22,7 @@ class GameSession(BaseModel):
 class GameLeaderboard(BaseModel):
     __tablename__ = 'game_leaderboards'
     
-    user_id = Column(Integer, ForeignKey('users.id'), nullable=False)
+    user_id = Column(BigInteger, ForeignKey('users.id'), nullable=False)
     game_type = Column(String(50), nullable=False)
     best_score = Column(Integer, default=0)
     total_games = Column(Integer, default=0)

--- a/models/mission.py
+++ b/models/mission.py
@@ -1,4 +1,4 @@
-from sqlalchemy import Column, Integer, String, Boolean, ForeignKey, Text, DateTime
+from sqlalchemy import Column, Integer, String, Boolean, ForeignKey, Text, DateTime, BigInteger
 from sqlalchemy.orm import relationship
 from sqlalchemy.sql import func
 from .base import BaseModel
@@ -19,7 +19,7 @@ class Mission(BaseModel):
 class UserMission(BaseModel):
     __tablename__ = 'user_missions'
     
-    user_id = Column(Integer, ForeignKey('users.id'), nullable=False)
+    user_id = Column(BigInteger, ForeignKey('users.id'), nullable=False)
     mission_id = Column(String(50), nullable=False)
     is_completed = Column(Boolean, default=False)
     completion_date = Column(String(10))  # YYYY-MM-DD format

--- a/models/user.py
+++ b/models/user.py
@@ -1,16 +1,16 @@
-from sqlalchemy import Column, Integer, String, Boolean
+from sqlalchemy import Column, Integer, String, Boolean, BigInteger
 from sqlalchemy.orm import relationship
 from .base import BaseModel
 
 class User(BaseModel):
     __tablename__ = 'users'
     
-    telegram_id = Column(Integer, unique=True, index=True, nullable=False)
+    telegram_id = Column(BigInteger, unique=True, index=True, nullable=False)
     username = Column(String(255))
     first_name = Column(String(255))
     level = Column(Integer, default=1)
     besitos = Column(Integer, default=100)
-    total_besitos_earned = Column(Integer, default=100)
+    total_besitos_earned = Column(BigInteger, default=100)
     current_story = Column(String(100), default="welcome")
     is_active = Column(Boolean, default=True)
     daily_streak = Column(Integer, default=0)


### PR DESCRIPTION
## Summary
- store Telegram's huge IDs using `BigInteger`
- update foreign keys for new integer size
- add `reset_db` helper for dev database resets

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68685a406e4883299125b135d13b39f0