### PR TITLE
Implement channel management basics

### DIFF
--- a/handlers/channel_access.py
+++ b/handlers/channel_access.py
@@ -1,0 +1,24 @@
+from aiogram import Router, types
+from aiogram.filters import Command
+from aiogram.fsm.context import FSMContext
+from services.channel_service import ChannelService
+from states.user_states import ChannelJoin
+
+router = Router()
+channel_service = ChannelService()
+
+@router.message(Command("join"))
+async def start_join(message: types.Message, state: FSMContext):
+    await message.answer("🔑 Envía tu token de acceso:")
+    await state.set_state(ChannelJoin.awaiting_token)
+
+@router.message(ChannelJoin.awaiting_token)
+async def process_token(message: types.Message, state: FSMContext):
+    token = message.text.strip()
+    user_id = message.from_user.id
+    success = await channel_service.validate_token(user_id, token)
+    if success:
+        await message.answer("✅ Token válido. Procesando acceso...")
+    else:
+        await message.answer("❌ Token inválido o expirado.")
+    await state.clear()

--- a/models/channel.py
+++ b/models/channel.py
@@ -1,0 +1,30 @@
+from sqlalchemy import Column, Integer, String, DateTime, Boolean, ForeignKey
+from sqlalchemy.ext.declarative import declarative_base
+from datetime import datetime
+
+Base = declarative_base()
+
+class ChannelAccess(Base):
+    __tablename__ = "channel_access"
+
+    id = Column(Integer, primary_key=True, index=True)
+    user_id = Column(Integer, ForeignKey("users.id"), nullable=False)
+    channel_id = Column(Integer, nullable=False)
+    is_vip = Column(Boolean, default=False)
+    is_pending = Column(Boolean, default=False)
+    pending_until = Column(DateTime, nullable=True)
+    access_granted = Column(DateTime, default=datetime.utcnow)
+    access_expires = Column(DateTime, nullable=True)
+    is_active = Column(Boolean, default=True)
+
+class ChannelToken(Base):
+    __tablename__ = "channel_tokens"
+
+    id = Column(Integer, primary_key=True, index=True)
+    token = Column(String, unique=True, nullable=False)
+    channel_id = Column(Integer, nullable=False)
+    is_vip = Column(Boolean, default=False)
+    max_uses = Column(Integer, default=1)
+    used_count = Column(Integer, default=0)
+    expires_at = Column(DateTime, nullable=False)
+    delay_seconds = Column(Integer, default=0)

--- a/services/channel_service.py
+++ b/services/channel_service.py
@@ -1,0 +1,93 @@
+from sqlalchemy.future import select
+from database_init import get_db
+from models.channel import ChannelToken, ChannelAccess
+from models.core import User
+from datetime import datetime, timedelta
+import secrets
+
+class ChannelService:
+    async def create_token(self, channel_id: int, is_vip: bool, days_valid: int = 1,
+                          max_uses: int = 1, delay_seconds: int = 0) -> ChannelToken:
+        token_str = secrets.token_urlsafe(8)
+        expires_at = datetime.utcnow() + timedelta(days=days_valid)
+        async for session in get_db():
+            new_token = ChannelToken(
+                token=token_str,
+                channel_id=channel_id,
+                is_vip=is_vip,
+                max_uses=max_uses,
+                expires_at=expires_at,
+                delay_seconds=delay_seconds,
+            )
+            session.add(new_token)
+            await session.commit()
+            await session.refresh(new_token)
+            return new_token
+
+    async def validate_token(self, telegram_id: int, token_str: str) -> bool:
+        async for session in get_db():
+            result = await session.execute(
+                select(ChannelToken).where(ChannelToken.token == token_str)
+            )
+            token = result.scalar_one_or_none()
+            if not token:
+                return False
+
+            if token.used_count >= token.max_uses or token.expires_at < datetime.utcnow():
+                return False
+
+            token.used_count += 1
+            await session.commit()
+
+            user_result = await session.execute(select(User).where(User.telegram_id == telegram_id))
+            user = user_result.scalar_one_or_none()
+            if not user:
+                return False
+
+            access = ChannelAccess(
+                user_id=user.id,
+                channel_id=token.channel_id,
+                is_vip=token.is_vip,
+                is_pending=token.delay_seconds > 0,
+                pending_until=datetime.utcnow() + timedelta(seconds=token.delay_seconds) if token.delay_seconds > 0 else None,
+                access_expires=datetime.utcnow() + timedelta(days=30) if token.is_vip else None,
+            )
+            session.add(access)
+            await session.commit()
+            return True
+
+    async def expire_access(self, bot):
+        async for session in get_db():
+            result = await session.execute(
+                select(ChannelAccess).where(
+                    ChannelAccess.is_active == True,
+                    ChannelAccess.access_expires != None,
+                    ChannelAccess.access_expires < datetime.utcnow()
+                )
+            )
+            expired = result.scalars().all()
+            for access in expired:
+                access.is_active = False
+                try:
+                    await bot.send_message(access.user_id, "🔒 Tu acceso ha expirado.")
+                except Exception:
+                    pass
+            await session.commit()
+
+    async def activate_pending(self, bot):
+        async for session in get_db():
+            result = await session.execute(
+                select(ChannelAccess).where(
+                    ChannelAccess.is_pending == True,
+                    ChannelAccess.pending_until != None,
+                    ChannelAccess.pending_until < datetime.utcnow()
+                )
+            )
+            pending = result.scalars().all()
+            for access in pending:
+                access.is_pending = False
+                try:
+                    await bot.send_message(access.user_id, "✅ Ahora tienes acceso al canal.")
+                except Exception:
+                    pass
+            await session.commit()

--- a/states/user_states.py
+++ b/states/user_states.py
@@ -6,3 +6,6 @@ class UserOnboarding(StatesGroup):
 
 class ViewingBackpack(StatesGroup):
     viewing = State()
+
+class ChannelJoin(StatesGroup):
+    awaiting_token = State()

--- a/tasks/channel_access.py
+++ b/tasks/channel_access.py
@@ -1,0 +1,7 @@
+from services.channel_service import ChannelService
+
+channel_service = ChannelService()
+
+async def process_channel_tasks(bot):
+    await channel_service.activate_pending(bot)
+    await channel_service.expire_access(bot)

--- a/utils/scheduler.py
+++ b/utils/scheduler.py
@@ -3,10 +3,12 @@ import asyncio
 from tasks.subscription_checker import check_expired_subscriptions
 from tasks.mission_assigner import assign_daily_missions
 from tasks.notification_dispatcher import dispatch_notifications
+from tasks.channel_access import process_channel_tasks
 
 async def run_scheduler(bot):
     while True:
         await check_expired_subscriptions(bot)
         await assign_daily_missions(bot)
         await dispatch_notifications(bot)
+        await process_channel_tasks(bot)
         await asyncio.sleep(3600)  # Ejecuta todas las tareas cada hora


### PR DESCRIPTION
## Summary
- define `ChannelAccess` and `ChannelToken` models
- add `ChannelService` for creating and validating tokens
- create handler and FSM state to process `/join` tokens
- schedule tasks for pending/expired channel access
- run scheduler with new task

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68686c5908708329a894795825024075