### PR TITLE
Add basic admin panel

### DIFF
--- a/core/bot.py
+++ b/core/bot.py
@@ -33,14 +33,19 @@ class DianaBot:
             # Import handlers básicos
             from handlers.base_handlers import BaseHandlers
             from handlers.mission_handlers import MissionHandlers
+            from handlers.admin import AdminHandlers
             
             # Comandos básicos
             self.application.add_handler(CommandHandler("start", BaseHandlers.start))
             self.application.add_handler(CommandHandler("help", BaseHandlers.help_command))
+            self.application.add_handler(CommandHandler("admin", AdminHandlers.admin_command))
+            self.application.add_handler(CommandHandler("stats", AdminHandlers.stats_command))
+            self.application.add_handler(CommandHandler("broadcast", AdminHandlers.broadcast_command))
             
             # Callback queries básicos
             self.application.add_handler(CallbackQueryHandler(BaseHandlers.button_handler))
             self.application.add_handler(CallbackQueryHandler(MissionHandlers.mission_handler, pattern="^(missions|mission_)") )
+            self.application.add_handler(CallbackQueryHandler(AdminHandlers.admin_callback, pattern="^admin_"))
             
             logger.info("✅ Handlers configurados correctamente")
             

--- a/handlers/admin.py
+++ b/handlers/admin.py
@@ -1,15 +1,66 @@
-
-from aiogram import Router, types
-from aiogram.filters import Command
-from aiogram.fsm.context import FSMContext
+from telegram import Update
+from telegram.ext import ContextTypes
 from utils.keyboards import get_admin_menu
 from utils.decorators import admin_only
-from states.admin_states import AdminMenu
+from services.admin_service import AdminService
 
-router = Router()
 
-@router.message(Command("admin"))
-@admin_only
-async def admin_menu(message: types.Message, state: FSMContext):
-    await message.answer("🛠️ Bienvenido al glorioso panel de administración. Trata de no romper nada.", reply_markup=get_admin_menu())
-    await state.set_state(AdminMenu.main)
+class AdminHandlers:
+    @staticmethod
+    @admin_only
+    async def admin_command(update: Update, context: ContextTypes.DEFAULT_TYPE):
+        await update.message.reply_text(
+            "\ud83d\udee0\ufe0f Bienvenido al glorioso panel de administraci\u00f3n. Trata de no romper nada.",
+            reply_markup=get_admin_menu()
+        )
+
+    @staticmethod
+    @admin_only
+    async def admin_callback(update: Update, context: ContextTypes.DEFAULT_TYPE):
+        query = update.callback_query
+        await query.answer()
+        service = AdminService()
+        if query.data == "admin_stats":
+            stats = await service.get_basic_stats()
+            text = (
+                f"\ud83d\udc65 Usuarios registrados: {stats['users']}\n"
+                f"\ud83d\udd11 Tokens VIP: {stats['vip_tokens']}"
+            )
+            await query.edit_message_text(text, reply_markup=get_admin_menu())
+        elif query.data == "admin_generate_token":
+            token = await service.generate_vip_token()
+            await query.edit_message_text(
+                f"\ud83d\udd11 Token generado: `{token}`",
+                reply_markup=get_admin_menu(),
+                parse_mode="Markdown"
+            )
+        elif query.data == "admin_broadcast":
+            await query.edit_message_text(
+                "Env\u00eda el mensaje a difundir usando /broadcast <texto>",
+                reply_markup=get_admin_menu()
+            )
+        else:
+            await query.edit_message_text(
+                "Acci\u00f3n no reconocida.", reply_markup=get_admin_menu()
+            )
+
+    @staticmethod
+    @admin_only
+    async def stats_command(update: Update, context: ContextTypes.DEFAULT_TYPE):
+        service = AdminService()
+        stats = await service.get_basic_stats()
+        await update.message.reply_text(
+            f"\ud83d\udc65 Usuarios registrados: {stats['users']}\n"
+            f"\ud83d\udd11 Tokens VIP: {stats['vip_tokens']}"
+        )
+
+    @staticmethod
+    @admin_only
+    async def broadcast_command(update: Update, context: ContextTypes.DEFAULT_TYPE):
+        if not context.args:
+            await update.message.reply_text("Uso: /broadcast <mensaje>")
+            return
+        message = " ".join(context.args)
+        service = AdminService()
+        await service.broadcast(context.bot, message)
+        await update.message.reply_text("Mensaje enviado")

--- a/handlers/story_handlers.py
+++ b/handlers/story_handlers.py
@@ -94,4 +94,21 @@ class StoryHandlers:
                 # Crear teclado con opciones
                 keyboard = []
                 for choice in scene_data["choices"]:
-                    # Verificar requisitos
+                    # Verificar requisitos (simplificado)
+                    keyboard.append([
+                        InlineKeyboardButton(choice.get("text", "Continuar"),
+                                             callback_data="main_menu")
+                    ])
+
+                await query.edit_message_text(
+                    scene_data.get("text", "..."),
+                    reply_markup=InlineKeyboardMarkup(keyboard),
+                    parse_mode="Markdown",
+                )
+
+            finally:
+                db.close()
+
+        except Exception as e:
+            logger.error(f"Error en chapter_handler: {e}")
+            await query.edit_message_text("❌ Error al cargar capítulo.")

--- a/keyboards/admin_inline.py
+++ b/keyboards/admin_inline.py
@@ -1,10 +1,10 @@
+from telegram import InlineKeyboardMarkup, InlineKeyboardButton
 
-from aiogram.types import InlineKeyboardMarkup, InlineKeyboardButton
 
 def get_admin_menu():
     keyboard = [
-        [InlineKeyboardButton(text="🗂️ Gestionar Misiones", callback_data="manage_missions")],
-        [InlineKeyboardButton(text="🔑 Gestionar Tokens VIP", callback_data="manage_tokens")],
-        [InlineKeyboardButton(text="🛠️ Configuraciones Generales", callback_data="edit_config")],
+        [InlineKeyboardButton(text="\ud83d\udcca Estad\u00edsticas", callback_data="admin_stats")],
+        [InlineKeyboardButton(text="\ud83c\udf7e Generar Token VIP", callback_data="admin_generate_token")],
+        [InlineKeyboardButton(text="\ud83d\xdce3 Broadcast", callback_data="admin_broadcast")],
     ]
-    return InlineKeyboardMarkup(inline_keyboard=keyboard)
+    return InlineKeyboardMarkup(keyboard)

--- a/services/progression.py
+++ b/services/progression.py
@@ -303,4 +303,9 @@ class ProgressionService:
                     "username": user.display_name,
                     "level": user.level,
                     "besitos": user.besitos,
-                    "telegram_id": user.telegram_id
+                    "telegram_id": user.telegram_id,
+                })
+            return leaderboard
+        except Exception as e:
+            logger.error(f"Error obteniendo leaderboard: {e}")
+            return []

--- a/utils/decorators.py
+++ b/utils/decorators.py
@@ -1,12 +1,18 @@
-
-from aiogram import types
+from functools import wraps
+from telegram import Update
+from telegram.ext import ContextTypes
 from config import ADMINS
 from utils.validators import is_admin
 
+
 def admin_only(handler):
-    async def wrapper(message: types.Message, *args, **kwargs):
-        if not is_admin(message.from_user.id, ADMINS):
-            await message.answer("🚫 No tienes permisos para acceder a esta función.")
+    @wraps(handler)
+    async def wrapper(update: Update, context: ContextTypes.DEFAULT_TYPE, *args, **kwargs):
+        user = update.effective_user
+        message = update.effective_message
+        if user is None or not is_admin(user.id, ADMINS):
+            if message:
+                await message.reply_text("\ud83d\uddb1 No tienes permisos para acceder a esta funci\u00f3n.")
             return
-        return await handler(message, *args, **kwargs)
+        return await handler(update, context, *args, **kwargs)
     return wrapper


### PR DESCRIPTION
## Summary
- switch admin keyboard to use python-telegram-bot
- implement admin commands for stats, broadcast and token generation
- wire admin handlers in bot setup
- update decorator for telegram library
- fix truncated files for compilation

## Testing
- `pytest -q`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_686871a33ff48329b09213af79314f1d