### PR TITLE
Implement channel management system

### DIFF
--- a/core/database.py
+++ b/core/database.py
@@ -34,10 +34,15 @@ def init_db():
     """Inicializa todas las tablas"""
     # Importar todos los modelos para registrarlos
     from models import user, mission, game_session
+    from models import channel_management
     
     Base.metadata.create_all(bind=engine)
     print("✅ Base de datos inicializada correctamente")
-    print("📊 Tablas creadas: users, missions, user_missions, game_sessions, game_leaderboards")
+    print(
+        "📊 Tablas creadas: users, missions, user_missions, game_sessions, "
+        "game_leaderboards, channels, channel_memberships, entry_tokens, "
+        "channel_settings"
+    )
 
 def reset_db():
     """Resetea la base de datos (solo para desarrollo)"""

--- a/handlers/admin_handlers.py
+++ b/handlers/admin_handlers.py
@@ -69,6 +69,10 @@ class AdminHandlers:
                 await AdminHandlers._show_admin_menu(query)
             elif query.data == "admin_users":
                 await AdminHandlers._show_users_management(query)
+            elif query.data == "admin_channels":
+                await AdminHandlers._show_channels_management(query)
+            elif query.data == "admin_tokens":
+                await AdminHandlers._show_tokens_management(query)
             elif query.data == "admin_stats":
                 await AdminHandlers._show_stats(query)
             else:
@@ -123,6 +127,52 @@ class AdminHandlers:
                 parse_mode='Markdown'
             )
             
+        finally:
+            db.close()
+
+    @staticmethod
+    async def _show_channels_management(query):
+        """Gestión de canales"""
+        db = get_db_session()
+        try:
+            from models.channel_management import Channel
+            total_channels = db.query(Channel).count()
+
+            text = (
+                f"📢 **Gestión de Canales**\n\n"
+                f"• Canales registrados: **{total_channels}**\n\n"
+                f"🚧 *Funciones avanzadas en desarrollo*"
+            )
+
+            await query.edit_message_text(
+                text,
+                reply_markup=admin_keyboards.back_to_admin_keyboard(),
+                parse_mode='Markdown',
+            )
+
+        finally:
+            db.close()
+
+    @staticmethod
+    async def _show_tokens_management(query):
+        """Gestión de tokens"""
+        db = get_db_session()
+        try:
+            from models.channel_management import EntryToken
+            total_tokens = db.query(EntryToken).count()
+
+            text = (
+                f"🎫 **Gestión de Tokens**\n\n"
+                f"• Tokens generados: **{total_tokens}**\n\n"
+                f"🚧 *Funciones avanzadas en desarrollo*"
+            )
+
+            await query.edit_message_text(
+                text,
+                reply_markup=admin_keyboards.back_to_admin_keyboard(),
+                parse_mode='Markdown',
+            )
+
         finally:
             db.close()
     

--- a/models/__init__.py
+++ b/models/__init__.py
@@ -1,3 +1,11 @@
-"""
-Models module - Modelos de base de datos
-"""
+"""Colección de modelos de base de datos."""
+
+from .user import User
+from .mission import Mission
+from .game_session import GameSession
+from .channel_management import (
+    Channel,
+    ChannelMembership,
+    EntryToken,
+    ChannelSettings,
+)

--- a/models/channel_management.py
+++ b/models/channel_management.py
@@ -1,0 +1,43 @@
+from sqlalchemy import Column, Integer, String, Boolean, DateTime, ForeignKey
+from datetime import datetime
+from .base import BaseModel
+
+
+class Channel(BaseModel):
+    __tablename__ = "channels"
+
+    name = Column(String, nullable=False)
+    invite_link = Column(String, nullable=True)
+    is_vip = Column(Boolean, default=False)
+
+
+class ChannelMembership(BaseModel):
+    __tablename__ = "channel_memberships"
+
+    user_id = Column(Integer, ForeignKey("users.id"), nullable=False)
+    channel_id = Column(Integer, ForeignKey("channels.id"), nullable=False)
+    is_vip = Column(Boolean, default=False)
+    is_pending = Column(Boolean, default=False)
+    pending_until = Column(DateTime, nullable=True)
+    expires_at = Column(DateTime, nullable=True)
+    is_active = Column(Boolean, default=True)
+
+
+class EntryToken(BaseModel):
+    __tablename__ = "entry_tokens"
+
+    token = Column(String, unique=True, nullable=False)
+    channel_id = Column(Integer, ForeignKey("channels.id"), nullable=False)
+    is_vip = Column(Boolean, default=False)
+    max_uses = Column(Integer, default=1)
+    used_count = Column(Integer, default=0)
+    expires_at = Column(DateTime, nullable=False)
+    delay_seconds = Column(Integer, default=0)
+
+
+class ChannelSettings(BaseModel):
+    __tablename__ = "channel_settings"
+
+    channel_id = Column(Integer, ForeignKey("channels.id"), unique=True, nullable=False)
+    join_delay_seconds = Column(Integer, default=0)
+    promo_message = Column(String, nullable=True)

--- a/tasks/channel_access.py
+++ b/tasks/channel_access.py
@@ -4,4 +4,4 @@ channel_service = ChannelService()
 
 async def process_channel_tasks(bot):
     await channel_service.activate_pending(bot)
-    await channel_service.expire_access(bot)
+    await channel_service.expire_memberships(bot)


### PR DESCRIPTION
## Summary
- add `channel_management` models for channels, memberships, tokens and settings
- initialize new models on DB startup
- expand `ChannelService` with registration, token creation and membership handling
- integrate channel/token management screens in admin panel
- schedule membership expiration with updated task

## Testing
- `pytest -q`
- `python -m py_compile models/channel_management.py services/channel_service.py handlers/admin_handlers.py tasks/channel_access.py core/database.py models/__init__.py`


------
https://chatgpt.com/codex/tasks/task_e_686883a11f4083299d5c380a2929ffd0