### PR TITLE
Implement token tariff generation

### DIFF
--- a/core/bot.py
+++ b/core/bot.py
@@ -1,4 +1,4 @@
-from telegram.ext import Application, CommandHandler, CallbackQueryHandler
+from telegram.ext import Application, CommandHandler, CallbackQueryHandler, MessageHandler, filters
 from .config import Config
 from .database import init_db
 import logging
@@ -44,6 +44,7 @@ class DianaBot:
             self.application.add_handler(CallbackQueryHandler(BaseHandlers.button_handler))
             self.application.add_handler(CallbackQueryHandler(MissionHandlers.mission_handler, pattern="^(missions|mission_)") )
             self.application.add_handler(CallbackQueryHandler(AdminHandlers.admin_handler, pattern="^admin_"))
+            self.application.add_handler(MessageHandler(filters.TEXT & ~filters.COMMAND, AdminHandlers.admin_text_handler))
             
             logger.info("✅ Handlers configurados correctamente")
             

--- a/core/database.py
+++ b/core/database.py
@@ -41,7 +41,7 @@ def init_db():
     print(
         "📊 Tablas creadas: users, missions, user_missions, game_sessions, "
         "game_leaderboards, channels, channel_memberships, entry_tokens, "
-        "channel_settings"
+        "channel_settings, token_tariffs"
     )
 
 def reset_db():

--- a/handlers/base_handlers.py
+++ b/handlers/base_handlers.py
@@ -3,6 +3,7 @@ from telegram.ext import ContextTypes
 from core.database import get_db_session
 from services.user_service import UserService
 from services.mission_tracker import MissionTracker
+from services.channel_service import ChannelService
 from utils.keyboards import main_menu, back_to_main
 from utils.formatters import MessageFormatter
 import logging
@@ -19,6 +20,7 @@ class BaseHandlers:
             logger.info(f"📨 Comando /start recibido de {update.effective_user.id}")
             
             user_data = update.effective_user
+            token_param = context.args[0] if context.args else None
             
             # Usar sesión directa
             db = get_db_session()
@@ -36,9 +38,15 @@ class BaseHandlers:
                     first_name=user_data.first_name
                 )
                 
+                if token_param:
+                    link = await ChannelService().validate_token(user_data.id, token_param)
+                    if link:
+                        await update.message.reply_text("✅ Token válido. Procesando acceso...")
+                        await update.message.reply_text(link)
+
                 # Mensaje de bienvenida
                 welcome_text = MessageFormatter.welcome_message(user, is_new_user)
-                
+
                 await update.message.reply_text(
                     welcome_text,
                     reply_markup=main_menu(),

--- a/handlers/channel_access.py
+++ b/handlers/channel_access.py
@@ -16,9 +16,10 @@ async def start_join(message: types.Message, state: FSMContext):
 async def process_token(message: types.Message, state: FSMContext):
     token = message.text.strip()
     user_id = message.from_user.id
-    success = await channel_service.validate_token(user_id, token)
-    if success:
+    link = await channel_service.validate_token(user_id, token)
+    if link:
         await message.answer("✅ Token válido. Procesando acceso...")
+        await message.answer(link)
     else:
         await message.answer("❌ Token inválido o expirado.")
     await state.clear()

--- a/models/__init__.py
+++ b/models/__init__.py
@@ -8,4 +8,5 @@ from .channel_management import (
     ChannelMembership,
     EntryToken,
     ChannelSettings,
+    TokenTariff,
 )

--- a/models/channel_management.py
+++ b/models/channel_management.py
@@ -41,3 +41,11 @@ class ChannelSettings(BaseModel):
     channel_id = Column(Integer, ForeignKey("channels.id"), unique=True, nullable=False)
     join_delay_seconds = Column(Integer, default=0)
     promo_message = Column(String, nullable=True)
+
+
+class TokenTariff(BaseModel):
+    __tablename__ = "token_tariffs"
+
+    name = Column(String, unique=True, nullable=False)
+    duration_days = Column(Integer, nullable=False)
+    cost = Column(Integer, nullable=False)

--- a/utils/keyboards.py
+++ b/utils/keyboards.py
@@ -214,12 +214,36 @@ class AdminKeyboards:
 
     def back_to_admin_keyboard(self) -> InlineKeyboardMarkup:
         """Botón para volver al menú admin"""
-        return InlineKeyboardMarkup([[
-            InlineKeyboardButton(
-                f"{self.EMOJIS['back']} Panel Admin",
-                callback_data="admin_menu"
-            )
-        ]])
+        return InlineKeyboardMarkup([
+            [
+                InlineKeyboardButton(
+                    f"{self.EMOJIS['back']} Panel Admin",
+                    callback_data="admin_menu",
+                )
+            ]
+        ])
+
+    def tokens_menu(self) -> InlineKeyboardMarkup:
+        buttons = [
+            [InlineKeyboardButton("⚙️ Configurar Tarifas", callback_data="token_tariffs")],
+            [InlineKeyboardButton("🔗 Generar Token", callback_data="token_generate")],
+            [InlineKeyboardButton(f"{self.EMOJIS['back']} Volver", callback_data="admin_menu")],
+        ]
+        return InlineKeyboardMarkup(buttons)
+
+    def tariff_duration_keyboard(self) -> InlineKeyboardMarkup:
+        buttons = [
+            [InlineKeyboardButton("1 día", callback_data="tariff_days_1"), InlineKeyboardButton("7 días", callback_data="tariff_days_7")],
+            [InlineKeyboardButton("15 días", callback_data="tariff_days_15"), InlineKeyboardButton("30 días", callback_data="tariff_days_30")],
+        ]
+        return InlineKeyboardMarkup(buttons)
+
+    def tariffs_list_keyboard(self, tariffs) -> InlineKeyboardMarkup:
+        rows = []
+        for t in tariffs:
+            rows.append([InlineKeyboardButton(t.name, callback_data=f"gen_tariff_{t.id}")])
+        rows.append([InlineKeyboardButton(f"{self.EMOJIS['back']} Volver", callback_data="admin_tokens")])
+        return InlineKeyboardMarkup(rows)
 
 # Instancias globales para compatibilidad
 user_keyboards = UserKeyboards()


### PR DESCRIPTION
## Summary
- add `TokenTariff` model for channel entry pricing
- extend `ChannelService` with tariff and token helpers
- enhance admin keyboards and handlers to configure tariffs and generate tokens
- handle token deep links from `/start`
- return channel invite link on token validation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68688e80333083299ae384c427555e63