### PR TITLE
Add role-based menus

### DIFF
--- a/handlers/onboarding.py
+++ b/handlers/onboarding.py
@@ -15,8 +15,8 @@ async def start_handler(message: types.Message, state: FSMContext):
     user = await user_service.get_or_create_user(message.from_user)
 
     if not user.is_onboarded:
-        await message.answer(welcome_message(user), reply_markup=get_main_menu())
+        await message.answer(welcome_message(user), reply_markup=get_main_menu(user))
         await state.set_state(UserOnboarding.onboarding_complete)
         await user_service.set_onboarded(user)
     else:
-        await message.answer(f"🍹 Oh, {user.first_name}... ya nos conocemos.", reply_markup=get_main_menu())
+        await message.answer(f"🍹 Oh, {user.first_name}... ya nos conocemos.", reply_markup=get_main_menu(user))

--- a/models/user.py
+++ b/models/user.py
@@ -1,6 +1,13 @@
-from sqlalchemy import Column, Integer, String, Boolean, BigInteger
+from sqlalchemy import Column, Integer, String, Boolean, BigInteger, DateTime, Enum, Float
 from sqlalchemy.orm import relationship
 from .base import BaseModel
+import enum
+
+
+class UserRole(enum.Enum):
+    ADMIN = "admin"
+    VIP = "vip"
+    FREE = "free"
 
 class User(BaseModel):
     __tablename__ = 'users'
@@ -14,17 +21,47 @@ class User(BaseModel):
     current_story = Column(String(100), default="welcome")
     is_active = Column(Boolean, default=True)
     daily_streak = Column(Integer, default=0)
-    
+
+    # Sistema de roles y beneficios VIP
+    role = Column(Enum(UserRole), default=UserRole.FREE)
+    vip_expires_at = Column(DateTime(timezone=True), nullable=True)
+    besitos_multiplier = Column(Float, default=1.0)
+
     # Relaciones (se definen después para evitar imports circulares)
     
     def __repr__(self):
-        return f"<User(telegram_id={self.telegram_id}, username='{self.username}', level={self.level})>"
+        return (
+            f"<User(telegram_id={self.telegram_id}, "
+            f"username='{self.username}', role={self.role.value})>"
+        )
     
     @property
     def display_name(self):
         """Retorna el nombre a mostrar del usuario"""
         return self.username or self.first_name or f"Usuario_{self.telegram_id}"
+
+    @property
+    def is_admin(self):
+        return self.role == UserRole.ADMIN
+
+    @property
+    def is_vip(self):
+        return self.role == UserRole.VIP
+
+    @property
+    def is_free(self):
+        return self.role == UserRole.FREE
+
+    @property
+    def role_emoji(self):
+        if self.is_admin:
+            return "👑"
+        elif self.is_vip:
+            return "💎"
+        else:
+            return "🆓"
     
     def can_afford(self, cost):
         """Verifica si el usuario puede pagar un costo en besitos"""
         return self.besitos >= cost
+

--- a/utils/formatters.py
+++ b/utils/formatters.py
@@ -27,6 +27,66 @@ class MessageFormatter:
                 f"📖 Historia: {user.current_story}\n\n"
                 f"*¿En qué puedo asistirte hoy?*"
             )
+
+    @staticmethod
+    def welcome_message_by_role(user, is_new_user=False):
+        """Mensaje de bienvenida según el rol del usuario"""
+
+        if user.is_admin:
+            return MessageFormatter._admin_welcome(user, is_new_user)
+        elif user.is_vip:
+            return MessageFormatter._vip_welcome(user, is_new_user)
+        else:
+            return MessageFormatter._free_welcome(user, is_new_user)
+
+    @staticmethod
+    def _admin_welcome(user, is_new_user):
+        return (
+            "👑 **Panel de Administración**\n\n"
+            f"Bienvenida, **{user.display_name}**.\n"
+            "Sistema DianaBot operativo y listo.\n\n"
+            "**Estado del sistema:**\n"
+            f"⭐ Tu nivel: **{user.level}**\n"
+            f"💋 Besitos: **{user.besitos}**\n\n"
+            "*Selecciona una función administrativa:*"
+        )
+
+    @staticmethod
+    def _vip_welcome(user, is_new_user):
+        multiplier_text = (
+            f" (x{user.besitos_multiplier})" if user.besitos_multiplier > 1.0 else ""
+        )
+        return (
+            "💎 **¡Bienvenida de vuelta, VIP!**\n\n"
+            f"Hola **{user.display_name}**, tu acceso premium está activo.\n\n"
+            "**Tu estado VIP:**\n"
+            f"⭐ Nivel: **{user.level}**\n"
+            f"💋 Besitos: **{user.besitos}**{multiplier_text}\n"
+            "👑 Membresía: **VIP Activa**\n\n"
+            "*Accede a tu contenido exclusivo:*"
+        )
+
+    @staticmethod
+    def _free_welcome(user, is_new_user):
+        if is_new_user:
+            return (
+                f"🎩 **¡Bienvenido a la mansión, {user.display_name}!**\n\n"
+                "Soy Lucien, mayordomo de Lady Diana 👑. "
+                "Ella ha expresado interés en conocerte.\n\n"
+                "**Tu estado inicial:**\n"
+                f"⭐ Nivel: **{user.level}**\n"
+                f"💋 Besitos: **{user.besitos}**\n\n"
+                "💎 *¿Te interesa el acceso VIP para contenido exclusivo?*"
+            )
+        else:
+            return (
+                f"🎩 **¡Bienvenido de vuelta, {user.display_name}!**\n\n"
+                "**Tu progreso actual:**\n"
+                f"⭐ Nivel: **{user.level}**\n"
+                f"💋 Besitos: **{user.besitos}**\n"
+                f"📖 Historia: *{user.current_story}*\n\n"
+                "💎 *¡Descubre los beneficios VIP!*"
+            )
     
     @staticmethod
     def user_profile(user):

--- a/utils/keyboards.py
+++ b/utils/keyboards.py
@@ -8,7 +8,7 @@ from models.user import User
 from typing import List, Optional, Dict, Any
 
 class UserKeyboards:
-    """Teclados intuitivos optimizados para usuarios no técnicos"""
+    """Teclados diferenciados por rol de usuario"""
 
     def __init__(self):
         # Emojis consistentes para toda la experiencia
@@ -74,6 +74,157 @@ class UserKeyboards:
             "broadcast": "📤",
             "config": "⚙️",
         }
+
+    def get_main_menu_by_role(self, user: User) -> InlineKeyboardMarkup:
+        """Retorna el menú principal según el rol del usuario"""
+        if user.is_admin:
+            return self.admin_main_menu()
+        elif user.is_vip:
+            return self.vip_main_menu(user)
+        else:
+            return self.free_main_menu(user)
+
+    def admin_main_menu(self) -> InlineKeyboardMarkup:
+        """Menú principal para administradores"""
+        buttons = [
+            [
+                InlineKeyboardButton(
+                    f"{self.EMOJIS['users']} Gestión de Usuarios",
+                    callback_data="admin_users",
+                ),
+                InlineKeyboardButton(
+                    f"{self.EMOJIS['channels']} Gestión de Canales",
+                    callback_data="admin_channels",
+                ),
+            ],
+            [
+                InlineKeyboardButton(
+                    f"{self.EMOJIS['tokens']} Tokens de Entrada",
+                    callback_data="admin_tokens",
+                ),
+                InlineKeyboardButton(
+                    f"{self.EMOJIS['stats']} Estadísticas",
+                    callback_data="admin_stats",
+                ),
+            ],
+            [
+                InlineKeyboardButton(
+                    f"{self.EMOJIS['broadcast']} Envío Masivo",
+                    callback_data="admin_broadcast",
+                ),
+                InlineKeyboardButton(
+                    f"{self.EMOJIS['config']} Configuración",
+                    callback_data="admin_config",
+                ),
+            ],
+            [
+                InlineKeyboardButton(
+                    f"{self.EMOJIS['play']} Vista de Usuario",
+                    callback_data="switch_to_user_view",
+                )
+            ],
+        ]
+        return InlineKeyboardMarkup(buttons)
+
+    def vip_main_menu(self, user: User) -> InlineKeyboardMarkup:
+        """Menú principal para usuarios VIP"""
+        buttons = []
+
+        buttons.append([
+            InlineKeyboardButton(
+                f"{self.EMOJIS['treasure']} Contenido Premium",
+                callback_data="vip_premium_content",
+            ),
+            InlineKeyboardButton(
+                f"{self.EMOJIS['auctions']} Subastas VIP",
+                callback_data="vip_auctions",
+            ),
+        ])
+
+        buttons.append([
+            InlineKeyboardButton(
+                f"{self.EMOJIS['missions']} Misiones VIP",
+                callback_data="missions",
+            ),
+            InlineKeyboardButton(
+                f"{self.EMOJIS['play']} Juegos VIP",
+                callback_data="games",
+            ),
+        ])
+
+        buttons.append([
+            InlineKeyboardButton(
+                f"{self.EMOJIS['profile']} Mi Perfil VIP",
+                callback_data="profile",
+            ),
+            InlineKeyboardButton(
+                f"{self.EMOJIS['gift']} Beneficios VIP",
+                callback_data="vip_benefits",
+            ),
+        ])
+
+        buttons.append([
+            InlineKeyboardButton(
+                f"{self.EMOJIS['story']} Historia Exclusiva",
+                callback_data="story",
+            ),
+            InlineKeyboardButton(
+                f"{self.EMOJIS['help']} Soporte VIP",
+                callback_data="vip_support",
+            ),
+        ])
+
+        return InlineKeyboardMarkup(buttons)
+
+    def free_main_menu(self, user: User) -> InlineKeyboardMarkup:
+        """Menú principal para usuarios gratuitos"""
+        buttons = []
+
+        buttons.append([
+            InlineKeyboardButton(
+                f"{self.EMOJIS['missions']} Misiones",
+                callback_data="missions",
+            ),
+            InlineKeyboardButton(
+                f"{self.EMOJIS['play']} Juegos",
+                callback_data="games",
+            ),
+        ])
+
+        buttons.append([
+            InlineKeyboardButton(
+                f"{self.EMOJIS['profile']} Mi Perfil",
+                callback_data="profile",
+            ),
+            InlineKeyboardButton(
+                f"{self.EMOJIS['story']} Historia",
+                callback_data="story",
+            ),
+        ])
+
+        buttons.append([
+            InlineKeyboardButton(
+                f"{self.EMOJIS['vip']} ¡Hazte VIP!",
+                callback_data="upgrade_to_vip",
+            ),
+            InlineKeyboardButton(
+                f"{self.EMOJIS['hot']} Canal Baby",
+                callback_data="join_baby_channel",
+            ),
+        ])
+
+        buttons.append([
+            InlineKeyboardButton(
+                f"{self.EMOJIS['shop']} Tienda",
+                callback_data="shop",
+            ),
+            InlineKeyboardButton(
+                f"{self.EMOJIS['help']} Ayuda",
+                callback_data="help",
+            ),
+        ])
+
+        return InlineKeyboardMarkup(buttons)
 
     def main_menu_keyboard(self, user: User) -> InlineKeyboardMarkup:
         """Menú principal - Diseñado para máxima claridad"""
@@ -250,15 +401,9 @@ user_keyboards = UserKeyboards()
 admin_keyboards = AdminKeyboards()
 
 # Funciones de compatibilidad con el código existente
-def main_menu():
-    """Función de compatibilidad"""
-    class DummyUser:
-        def __init__(self):
-            self.level = 1
-            self.besitos = 100
-
-    dummy_user = DummyUser()
-    return user_keyboards.main_menu_keyboard(dummy_user)
+def main_menu(user: User):
+    """Función de compatibilidad - requiere usuario"""
+    return user_keyboards.get_main_menu_by_role(user)
 
 def back_to_main():
     """Función de compatibilidad"""
@@ -286,9 +431,9 @@ def profile_menu():
     ]])
 
 # Aliases y utilidades para compatibilidad con código antiguo
-def get_main_menu():
+def get_main_menu(user: User):
     """Alias para obtener el menú principal"""
-    return main_menu()
+    return main_menu(user)
 
 def get_mission_keyboard(missions: List[Any]) -> InlineKeyboardMarkup:
     """Genera un teclado para seleccionar misiones"""


### PR DESCRIPTION
## Summary
- define `UserRole` enum and role fields on the user model
- build role-specific keyboards (admin, VIP and free)
- format welcome messages per user role
- update handlers to send menus according to role
- adjust onboarding to support new keyboard API

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6868910a34988329891dd7f5abe8fc4f