### PR TITLE
Add basic channel management models and services

### DIFF
--- a/core/database.py
+++ b/core/database.py
@@ -34,14 +34,14 @@ def init_db():
     """Inicializa todas las tablas"""
     # Importar todos los modelos para registrarlos
     from models import user, mission, game_session
-    from models import channel_management
+    from models import channel
     
     Base.metadata.create_all(bind=engine)
     print("✅ Base de datos inicializada correctamente")
     print(
         "📊 Tablas creadas: users, missions, user_missions, game_sessions, "
         "game_leaderboards, channels, channel_memberships, entry_tokens, "
-        "channel_settings, token_tariffs"
+        "channel_tariffs"
     )
 
 def reset_db():

--- a/handlers/channel_handlers.py
+++ b/handlers/channel_handlers.py
@@ -1,0 +1,75 @@
+from telegram import Update, InlineKeyboardButton, InlineKeyboardMarkup
+from telegram.ext import ContextTypes
+from core.database import get_db_session
+from services.channel_service import ChannelService
+from models.channel import ChannelType
+from utils.keyboards import admin_keyboards
+import logging
+
+logger = logging.getLogger(__name__)
+
+class ChannelHandlers:
+    """Handlers para gestión de canales"""
+
+    @staticmethod
+    async def channel_management_handler(update: Update, context: ContextTypes.DEFAULT_TYPE):
+        """Handler principal para gestión de canales"""
+        try:
+            query = update.callback_query
+            await query.answer()
+
+            if query.data == "admin_channels":
+                await ChannelHandlers._show_channel_menu(query)
+            elif query.data == "channel_register":
+                await ChannelHandlers._show_register_options(query)
+            elif query.data == "channel_list":
+                await ChannelHandlers._show_channel_list(query)
+            elif query.data == "channel_tariffs":
+                await ChannelHandlers._show_tariff_management(query)
+
+        except Exception as e:
+            logger.error(f"Error en channel_management_handler: {e}")
+            await query.edit_message_text("❌ Error procesando gestión de canales.")
+
+    @staticmethod
+    async def _show_channel_menu(query):
+        """Muestra el menú principal de gestión de canales"""
+        db = get_db_session()
+
+        try:
+            channels = ChannelService.get_channels(db)
+
+            text = (
+                "📢 Gestión de Canales\n\n"
+                f"Canales registrados: {len(channels)}\n\n"
+                "Selecciona una opción:"
+            )
+
+            keyboard = [
+                [InlineKeyboardButton("➕ Registrar Canal", callback_data="channel_register")],
+                [InlineKeyboardButton("📋 Ver Canales", callback_data="channel_list")],
+                [InlineKeyboardButton("💰 Gestionar Tarifas", callback_data="channel_tariffs")],
+                [InlineKeyboardButton("🎫 Generar Tokens", callback_data="channel_tokens")],
+                [InlineKeyboardButton("◀️ Panel Admin", callback_data="admin_menu")]
+            ]
+
+            await query.edit_message_text(
+                text,
+                reply_markup=InlineKeyboardMarkup(keyboard)
+            )
+
+        finally:
+            db.close()
+
+    # Métodos placeholder para futuras implementaciones
+    @staticmethod
+    async def _show_register_options(query):
+        await query.edit_message_text("🚧 Función en desarrollo", reply_markup=admin_keyboards.back_to_admin_keyboard())
+
+    @staticmethod
+    async def _show_channel_list(query):
+        await query.edit_message_text("🚧 Función en desarrollo", reply_markup=admin_keyboards.back_to_admin_keyboard())
+
+    @staticmethod
+    async def _show_tariff_management(query):
+        await query.edit_message_text("🚧 Función en desarrollo", reply_markup=admin_keyboards.back_to_admin_keyboard())

--- a/models/__init__.py
+++ b/models/__init__.py
@@ -3,10 +3,10 @@
 from .user import User
 from .mission import Mission
 from .game_session import GameSession
-from .channel_management import (
+from .channel import (
     Channel,
-    ChannelMembership,
+    ChannelTariff,
     EntryToken,
-    ChannelSettings,
-    TokenTariff,
+    ChannelMembership,
+    ChannelType,
 )

--- a/models/channel.py
+++ b/models/channel.py
@@ -1,30 +1,68 @@
-from sqlalchemy import Column, Integer, String, DateTime, Boolean, ForeignKey
-from sqlalchemy.ext.declarative import declarative_base
-from datetime import datetime
+from sqlalchemy import Column, Integer, String, Boolean, BigInteger, DateTime, Float, Text, ForeignKey, Enum
+from sqlalchemy.orm import relationship
+from sqlalchemy.sql import func
+from .base import BaseModel
+import enum
 
-Base = declarative_base()
+class ChannelType(enum.Enum):
+    VIP = "vip"
+    FREE = "free"
 
-class ChannelAccess(Base):
-    __tablename__ = "channel_access"
+class Channel(BaseModel):
+    __tablename__ = 'channels'
 
-    id = Column(Integer, primary_key=True, index=True)
-    user_id = Column(Integer, ForeignKey("users.id"), nullable=False)
-    channel_id = Column(Integer, nullable=False)
-    is_vip = Column(Boolean, default=False)
-    is_pending = Column(Boolean, default=False)
-    pending_until = Column(DateTime, nullable=True)
-    access_granted = Column(DateTime, default=datetime.utcnow)
-    access_expires = Column(DateTime, nullable=True)
+    channel_id = Column(BigInteger, unique=True, nullable=False, index=True)
+    channel_name = Column(String(255), nullable=False)
+    channel_type = Column(Enum(ChannelType), nullable=False)
     is_active = Column(Boolean, default=True)
 
-class ChannelToken(Base):
-    __tablename__ = "channel_tokens"
+    # Configuraciones específicas
+    auto_accept = Column(Boolean, default=False)
+    accept_delay = Column(Integer, default=0)
+    welcome_message = Column(Text)
 
-    id = Column(Integer, primary_key=True, index=True)
-    token = Column(String, unique=True, nullable=False)
-    channel_id = Column(Integer, nullable=False)
-    is_vip = Column(Boolean, default=False)
-    max_uses = Column(Integer, default=1)
-    used_count = Column(Integer, default=0)
-    expires_at = Column(DateTime, nullable=False)
-    delay_seconds = Column(Integer, default=0)
+    # Relaciones
+    tariffs = relationship("ChannelTariff", back_populates="channel")
+    memberships = relationship("ChannelMembership", back_populates="channel")
+
+class ChannelTariff(BaseModel):
+    __tablename__ = 'channel_tariffs'
+
+    channel_id = Column(BigInteger, ForeignKey('channels.id'), nullable=False)
+    name = Column(String(100), nullable=False)
+    duration_days = Column(Integer, nullable=False)
+    price_besitos = Column(Integer, nullable=False)
+    is_active = Column(Boolean, default=True)
+
+    # Relaciones
+    channel = relationship("Channel", back_populates="tariffs")
+    tokens = relationship("EntryToken", back_populates="tariff")
+
+class EntryToken(BaseModel):
+    __tablename__ = 'entry_tokens'
+
+    token = Column(String(255), unique=True, nullable=False, index=True)
+    tariff_id = Column(BigInteger, ForeignKey('channel_tariffs.id'), nullable=False)
+    created_by = Column(BigInteger, nullable=False)
+    expires_at = Column(DateTime(timezone=True), nullable=False)
+    is_used = Column(Boolean, default=False)
+    used_by = Column(BigInteger, nullable=True)
+    used_at = Column(DateTime(timezone=True), nullable=True)
+
+    # Relaciones
+    tariff = relationship("ChannelTariff", back_populates="tokens")
+
+class ChannelMembership(BaseModel):
+    __tablename__ = 'channel_memberships'
+
+    user_id = Column(BigInteger, ForeignKey('users.id'), nullable=False)
+    channel_id = Column(BigInteger, ForeignKey('channels.id'), nullable=False)
+    joined_at = Column(DateTime(timezone=True), server_default=func.now())
+    expires_at = Column(DateTime(timezone=True), nullable=True)
+    is_active = Column(Boolean, default=True)
+    entry_token_id = Column(BigInteger, ForeignKey('entry_tokens.id'), nullable=True)
+
+    # Relaciones
+    user = relationship("User")
+    channel = relationship("Channel", back_populates="memberships")
+    entry_token = relationship("EntryToken")

--- a/services/channel_service.py
+++ b/services/channel_service.py
@@ -1,146 +1,112 @@
-from sqlalchemy.future import select
-from database_init import get_db
-from models.channel_management import (
-    Channel,
-    ChannelMembership,
-    EntryToken,
-    ChannelSettings,
-    TokenTariff,
-)
+from sqlalchemy.orm import Session
+from models.channel import Channel, ChannelTariff, EntryToken, ChannelMembership, ChannelType
 from models.user import User
 from datetime import datetime, timedelta
 import secrets
+import string
+import logging
 
+logger = logging.getLogger(__name__)
 
 class ChannelService:
-    async def register_channel(self, name: str, invite_link: str = None, is_vip: bool = False) -> Channel:
-        async for session in get_db():
-            channel = Channel(name=name, invite_link=invite_link, is_vip=is_vip)
-            session.add(channel)
-            await session.commit()
-            await session.refresh(channel)
+    """Servicio para gestión de canales"""
+
+    @staticmethod
+    def register_channel(db: Session, channel_id: int, channel_name: str, channel_type: ChannelType) -> Channel:
+        """Registra un nuevo canal"""
+        try:
+            existing = db.query(Channel).filter(Channel.channel_id == channel_id).first()
+            if existing:
+                raise ValueError(f"Canal {channel_id} ya está registrado")
+
+            channel = Channel(
+                channel_id=channel_id,
+                channel_name=channel_name,
+                channel_type=channel_type
+            )
+
+            db.add(channel)
+            db.commit()
+            db.refresh(channel)
+
+            logger.info(f"Canal registrado: {channel_name} ({channel_type.value})")
             return channel
 
-    async def create_tariff(self, name: str, duration_days: int, cost: int) -> TokenTariff:
-        async for session in get_db():
-            tariff = TokenTariff(name=name, duration_days=duration_days, cost=cost)
-            session.add(tariff)
-            await session.commit()
-            await session.refresh(tariff)
+        except Exception as e:
+            logger.error(f"Error registrando canal: {e}")
+            db.rollback()
+            raise
+
+    @staticmethod
+    def create_tariff(db: Session, channel_id: int, name: str, duration_days: int, price_besitos: int) -> ChannelTariff:
+        """Crea una nueva tarifa para un canal"""
+        try:
+            channel = db.query(Channel).filter(Channel.id == channel_id).first()
+            if not channel:
+                raise ValueError("Canal no encontrado")
+
+            tariff = ChannelTariff(
+                channel_id=channel_id,
+                name=name,
+                duration_days=duration_days,
+                price_besitos=price_besitos
+            )
+
+            db.add(tariff)
+            db.commit()
+            db.refresh(tariff)
+
+            logger.info(f"Tarifa creada: {name} - {duration_days} días - {price_besitos} besitos")
             return tariff
 
-    async def get_tariffs(self):
-        async for session in get_db():
-            result = await session.execute(select(TokenTariff))
-            return result.scalars().all()
+        except Exception as e:
+            logger.error(f"Error creando tarifa: {e}")
+            db.rollback()
+            raise
 
-    async def get_tariff(self, tariff_id: int) -> TokenTariff | None:
-        async for session in get_db():
-            result = await session.execute(select(TokenTariff).where(TokenTariff.id == tariff_id))
-            return result.scalar_one_or_none()
+    @staticmethod
+    def generate_entry_token(db: Session, tariff_id: int, created_by: int) -> str:
+        """Genera un token de entrada único"""
+        try:
+            tariff = db.query(ChannelTariff).filter(ChannelTariff.id == tariff_id).first()
+            if not tariff:
+                raise ValueError("Tarifa no encontrada")
 
-    async def create_entry_token(
-        self,
-        channel_id: int,
-        is_vip: bool,
-        days_valid: int = 1,
-        max_uses: int = 1,
-        delay_seconds: int = 0,
-    ) -> EntryToken:
-        token_str = secrets.token_urlsafe(8)
-        expires_at = datetime.utcnow() + timedelta(days=days_valid)
-        async for session in get_db():
-            token = EntryToken(
-                token=token_str,
-                channel_id=channel_id,
-                is_vip=is_vip,
-                max_uses=max_uses,
-                expires_at=expires_at,
-                delay_seconds=delay_seconds,
+            token = ''.join(secrets.choice(string.ascii_letters + string.digits) for _ in range(32))
+
+            expires_at = datetime.utcnow() + timedelta(days=tariff.duration_days)
+
+            entry_token = EntryToken(
+                token=token,
+                tariff_id=tariff_id,
+                created_by=created_by,
+                expires_at=expires_at
             )
-            session.add(token)
-            await session.commit()
-            await session.refresh(token)
-            return token
 
-    async def create_token_from_tariff(self, channel_id: int, tariff_id: int, is_vip: bool = False) -> EntryToken | None:
-        tariff = await self.get_tariff(tariff_id)
-        if not tariff:
-            return None
-        return await self.create_entry_token(
-            channel_id=channel_id,
-            is_vip=is_vip,
-            days_valid=tariff.duration_days,
-        )
+            db.add(entry_token)
+            db.commit()
+            db.refresh(entry_token)
 
-    async def validate_token(self, telegram_id: int, token_str: str) -> str | None:
-        async for session in get_db():
-            result = await session.execute(select(EntryToken).where(EntryToken.token == token_str))
-            token = result.scalar_one_or_none()
-            if not token:
-                return None
+            bot_username = "tu_bot_username"
+            link = f"https://t.me/{bot_username}?start={token}"
 
-            if token.used_count >= token.max_uses or token.expires_at < datetime.utcnow():
-                return None
+            logger.info(f"Token generado: {token}")
+            return link
 
-            token.used_count += 1
-            await session.commit()
+        except Exception as e:
+            logger.error(f"Error generando token: {e}")
+            db.rollback()
+            raise
 
-            user_result = await session.execute(select(User).where(User.telegram_id == telegram_id))
-            user = user_result.scalar_one_or_none()
-            if not user:
-                return None
+    @staticmethod
+    def get_channels(db: Session) -> list:
+        """Obtiene todos los canales registrados"""
+        return db.query(Channel).filter(Channel.is_active == True).all()
 
-            membership = ChannelMembership(
-                user_id=user.id,
-                channel_id=token.channel_id,
-                is_vip=token.is_vip,
-                is_pending=token.delay_seconds > 0,
-                pending_until=(
-                    datetime.utcnow() + timedelta(seconds=token.delay_seconds)
-                    if token.delay_seconds > 0
-                    else None
-                ),
-                expires_at=datetime.utcnow() + timedelta(days=30) if token.is_vip else None,
-            )
-            session.add(membership)
-            await session.commit()
-            channel_res = await session.execute(select(Channel).where(Channel.id == token.channel_id))
-            channel = channel_res.scalar_one_or_none()
-            return channel.invite_link if channel else None
-
-    async def expire_memberships(self, bot):
-        async for session in get_db():
-            result = await session.execute(
-                select(ChannelMembership).where(
-                    ChannelMembership.is_active == True,
-                    ChannelMembership.expires_at != None,
-                    ChannelMembership.expires_at < datetime.utcnow(),
-                )
-            )
-            expired = result.scalars().all()
-            for membership in expired:
-                membership.is_active = False
-                try:
-                    await bot.send_message(membership.user_id, "🔒 Tu acceso ha expirado.")
-                except Exception:
-                    pass
-            await session.commit()
-
-    async def activate_pending(self, bot):
-        async for session in get_db():
-            result = await session.execute(
-                select(ChannelMembership).where(
-                    ChannelMembership.is_pending == True,
-                    ChannelMembership.pending_until != None,
-                    ChannelMembership.pending_until < datetime.utcnow(),
-                )
-            )
-            pending = result.scalars().all()
-            for membership in pending:
-                membership.is_pending = False
-                try:
-                    await bot.send_message(membership.user_id, "✅ Ahora tienes acceso al canal.")
-                except Exception:
-                    pass
-            await session.commit()
+    @staticmethod
+    def get_channel_tariffs(db: Session, channel_id: int) -> list:
+        """Obtiene las tarifas de un canal"""
+        return db.query(ChannelTariff).filter(
+            ChannelTariff.channel_id == channel_id,
+            ChannelTariff.is_active == True
+        ).all()


### PR DESCRIPTION
## Summary
- implement database models for channels and tariffs
- add synchronous channel service for registering channels and tariffs
- provide admin channel handler with placeholder actions
- update model registry and DB initialization

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686966042b4c83299f3f26dcfe4679cb