### PR TITLE
Add channel management handler

### DIFF
--- a/core/bot.py
+++ b/core/bot.py
@@ -40,14 +40,22 @@ class DianaBot:
             # Import handlers
             from handlers.base_handlers import BaseHandlers
             from handlers.admin_handlers import AdminHandlers
+            from handlers.channel_handlers import ChannelHandlers  # ← AÑADIR
 
             # Comandos básicos
             self.application.add_handler(CommandHandler("start", BaseHandlers.start))
             self.application.add_handler(CommandHandler("help", BaseHandlers.help_command))
             self.application.add_handler(CommandHandler("admin", AdminHandlers.admin_command))
 
+
             # ✅ UN SOLO HANDLER PARA TODOS LOS CALLBACKS
             self.application.add_handler(CallbackQueryHandler(BaseHandlers.button_handler))
+
+            # ✅ AÑADIR HANDLER ESPECÍFICO PARA CANALES
+            self.application.add_handler(CallbackQueryHandler(
+                ChannelHandlers.channel_management_handler,
+                pattern="^(channel_|admin_channels)$"
+            ))
 
             logger.info("✅ Handlers configurados correctamente")
 

--- a/handlers/admin_handlers.py
+++ b/handlers/admin_handlers.py
@@ -165,23 +165,12 @@ class AdminHandlers:
 
     @staticmethod
     async def _show_channels_management(query):
-        """Muestra gestión de canales - SIN MARKDOWN"""
-        text = (
-            "📢 Gestión de Canales\n\n"
-            "🚧 Próximamente disponible:\n"
-            "• Registrar canales VIP y gratuitos\n"
-            "• Configurar delays de entrada\n"
-            "• Gestionar auto-expulsiones\n"
-            "• Ver miembros por canal\n"
-            "• Configurar mensajes promocionales\n\n"
-            "Esta será la función principal para monetización."
-        )
+        """Muestra gestión de canales - AHORA FUNCIONAL"""
+        # Importar el nuevo handler
+        from handlers.channel_handlers import ChannelHandlers
 
-        await query.edit_message_text(
-            text,
-            reply_markup=admin_keyboards.back_to_admin_keyboard()
-            # ✅ SIN parse_mode
-        )
+        # Redirigir al handler específico de canales
+        await ChannelHandlers._show_channel_menu(query)
 
     @staticmethod
     async def _show_tokens_management(query):

--- a/handlers/base_handlers.py
+++ b/handlers/base_handlers.py
@@ -158,8 +158,6 @@ class BaseHandlers:
                 
                     if query.data == "admin_users":
                         await AdminHandlers._show_users_management(query)
-                    elif query.data == "admin_channels":  # ← AÑADIR
-                        await AdminHandlers._show_channels_management(query)
                     elif query.data == "admin_tokens":  # ← AÑADIR
                         await AdminHandlers._show_tokens_management(query)
                     elif query.data == "admin_stats":
@@ -180,6 +178,10 @@ class BaseHandlers:
                             # ✅ SIN parse_mode para evitar errores
                         )
         
+                elif query.data == "admin_channels":
+                    logger.info("📢 Redirigiendo a gestión de canales")
+                    from handlers.channel_handlers import ChannelHandlers
+                    await ChannelHandlers.channel_management_handler(update, context)
                 elif query.data in ["missions", "games", "story"]:
                         logger.info(f"🎮 Procesando: {query.data}")
                         await query.edit_message_text(

--- a/handlers/channel_handlers.py
+++ b/handlers/channel_handlers.py
@@ -64,12 +64,73 @@ class ChannelHandlers:
     # Métodos placeholder para futuras implementaciones
     @staticmethod
     async def _show_register_options(query):
-        await query.edit_message_text("🚧 Función en desarrollo", reply_markup=admin_keyboards.back_to_admin_keyboard())
+        """Muestra opciones para registrar canal"""
+        text = (
+            "➕ Registrar Nuevo Canal\n\n"
+            "Selecciona el tipo de canal:"
+        )
+
+        keyboard = [
+            [InlineKeyboardButton("💎 Canal VIP", callback_data="register_vip")],
+            [InlineKeyboardButton("🆓 Canal Gratuito", callback_data="register_free")],
+            [InlineKeyboardButton("◀️ Volver", callback_data="admin_channels")]
+        ]
+
+        await query.edit_message_text(
+            text,
+            reply_markup=InlineKeyboardMarkup(keyboard)
+        )
 
     @staticmethod
     async def _show_channel_list(query):
-        await query.edit_message_text("🚧 Función en desarrollo", reply_markup=admin_keyboards.back_to_admin_keyboard())
+        """Muestra lista de canales registrados"""
+        db = get_db_session()
+
+        try:
+            channels = ChannelService.get_channels(db)
+
+            text = "📋 Canales Registrados\n\n"
+
+            if not channels:
+                text += "No hay canales registrados aún."
+            else:
+                for channel in channels:
+                    emoji = "💎" if channel.channel_type.value == "vip" else "🆓"
+                    status = "🟢" if channel.is_active else "🔴"
+                    text += f"{emoji} {status} {channel.channel_name}\n"
+                    text += f"   ID: {channel.channel_id}\n"
+                    text += f"   Tipo: {channel.channel_type.value.upper()}\n\n"
+
+            keyboard = [
+                [InlineKeyboardButton("➕ Registrar Canal", callback_data="channel_register")],
+                [InlineKeyboardButton("◀️ Volver", callback_data="admin_channels")]
+            ]
+
+            await query.edit_message_text(
+                text,
+                reply_markup=InlineKeyboardMarkup(keyboard)
+            )
+
+        finally:
+            db.close()
 
     @staticmethod
     async def _show_tariff_management(query):
-        await query.edit_message_text("🚧 Función en desarrollo", reply_markup=admin_keyboards.back_to_admin_keyboard())
+        """Muestra gestión de tarifas"""
+        text = (
+            "💰 Gestión de Tarifas\n\n"
+            "🚧 Próximamente disponible:\n"
+            "• Crear tarifas personalizadas\n"
+            "• Configurar precios y duración\n"
+            "• Gestionar tarifas existentes\n\n"
+            "Esta función estará lista en la siguiente fase."
+        )
+
+        keyboard = [
+            [InlineKeyboardButton("◀️ Volver", callback_data="admin_channels")]
+        ]
+
+        await query.edit_message_text(
+            text,
+            reply_markup=InlineKeyboardMarkup(keyboard)
+        )


### PR DESCRIPTION
## Summary
- connect channel management menu to admin handlers
- register ChannelHandlers in bot setup
- route `admin_channels` callback via BaseHandlers
- implement functional channel menu helpers

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686968789e3c8329a17475723028ab1f