### PR TITLE
Fix admin ID configuration

### DIFF
--- a/handlers/admin_handlers.py
+++ b/handlers/admin_handlers.py
@@ -10,12 +10,13 @@ from utils.keyboards import admin_keyboards, user_keyboards
 from utils.formatters import MessageFormatter
 from models.user import User, UserRole
 from sqlalchemy import func  # Import necesario para funciones agregadas
+from config import ADMINS
 import logging
 
 logger = logging.getLogger(__name__)
 
 # IDs de administradores autorizados
-ADMIN_IDS = [6181290784]  # Tu Telegram ID
+ADMIN_IDS = ADMINS
 
 
 class AdminHandlers:

--- a/handlers/base_handlers.py
+++ b/handlers/base_handlers.py
@@ -6,6 +6,7 @@ from services.channel_service import ChannelService
 from utils.keyboards import user_keyboards, admin_keyboards, back_to_main
 from models.user import UserRole
 from utils.formatters import MessageFormatter
+from config import ADMINS
 import logging
 
 logger = logging.getLogger(__name__)
@@ -39,7 +40,7 @@ class BaseHandlers:
                 )
 
                 # Asignar rol de administrador si corresponde
-                if user_data.id in [6181290784]:
+                if user_data.id in ADMINS:
                     user.role = UserRole.ADMIN
                     db.commit()
                     db.refresh(user)


### PR DESCRIPTION
## Summary
- import ADMINS constant in admin handlers and base handlers
- use ADMINS list when checking for admin IDs so /admin menu works properly

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68697269892883298272853e94355a09