### PR TITLE
Improve channel registration validation

### DIFF
--- a/core/bot.py
+++ b/core/bot.py
@@ -51,6 +51,7 @@ class DianaBot:
             # ✅ COMANDOS DE ADMINISTRADOR
             self.application.add_handler(CommandHandler("register_channel", AdminCommands.register_channel_command))
             self.application.add_handler(CommandHandler("list_channels", AdminCommands.list_channels_command))
+            self.application.add_handler(CommandHandler("test_register", AdminCommands.test_register_command))
 
 
             # ✅ UN SOLO HANDLER PARA TODOS LOS CALLBACKS


### PR DESCRIPTION
## Summary
- refine `/register_channel` with detailed validation and logging
- add `/test_register` debugging command
- register new debug command in bot setup

## Testing
- `pytest -q`
- `python -m py_compile services/admin_commands.py core/bot.py`


------
https://chatgpt.com/codex/tasks/task_e_68697f2c06fc8329ad8447d24e3522c6