### PR TITLE
Improve channel registration, add cleanup command

### DIFF
--- a/core/bot.py
+++ b/core/bot.py
@@ -51,6 +51,7 @@ class DianaBot:
             # ✅ COMANDOS DE ADMINISTRADOR
             self.application.add_handler(CommandHandler("register_channel", AdminCommands.register_channel_command))
             self.application.add_handler(CommandHandler("list_channels", AdminCommands.list_channels_command))
+            self.application.add_handler(CommandHandler("clear_channels", AdminCommands.clear_channels_command))
 
 
             # ✅ UN SOLO HANDLER PARA TODOS LOS CALLBACKS

--- a/services/channel_service.py
+++ b/services/channel_service.py
@@ -13,11 +13,13 @@ class ChannelService:
 
     @staticmethod
     def register_channel(db: Session, channel_id: int, channel_name: str, channel_type: ChannelType) -> Channel:
-        """Registra un nuevo canal"""
+        """Registra un nuevo canal - MEJORADO"""
         try:
+            logger.info(f"Iniciando registro de canal: {channel_id}")
+
             existing = db.query(Channel).filter(Channel.channel_id == channel_id).first()
             if existing:
-                raise ValueError(f"Canal {channel_id} ya está registrado")
+                raise ValueError(f"Canal {channel_id} ya está registrado como '{existing.channel_name}'")
 
             channel = Channel(
                 channel_id=channel_id,
@@ -25,11 +27,19 @@ class ChannelService:
                 channel_type=channel_type
             )
 
-            db.add(channel)
-            db.commit()
-            db.refresh(channel)
+            logger.info(f"Canal creado en memoria: {channel_name}")
 
-            logger.info(f"Canal registrado: {channel_name} ({channel_type.value})")
+            db.add(channel)
+            db.flush()
+            logger.info("Canal añadido a sesión BD")
+
+            db.commit()
+            logger.info("Canal commitado a BD")
+
+            db.refresh(channel)
+            logger.info(f"Canal refrescado desde BD: ID={channel.id}")
+
+            logger.info(f"Canal registrado exitosamente: {channel_name} ({channel_type.value})")
             return channel
 
         except Exception as e:


### PR DESCRIPTION
## Summary
- handle validation and DB session cleanup in `register_channel_command`
- add `/clear_channels` admin command
- improve database interaction in `ChannelService.register_channel`
- wire up `clear_channels` command in bot setup

## Testing
- `pytest -q`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6869814e691c83298cefb79b9dc51823