### PR TITLE
Fix admin callbacks and add channel command utilities

### DIFF
--- a/handlers/base_handlers.py
+++ b/handlers/base_handlers.py
@@ -152,37 +152,33 @@ class BaseHandlers:
                 # ✅ CALLBACKS DE ADMIN - MANEJAR AQUÍ TEMPORALMENTE
                 elif query.data.startswith("admin_") or query.data == "switch_to_user_view":
                     logger.info(f"🔧 Procesando callback admin: {query.data}")
-                
+
                     if not AdminHandlers.is_admin(user_data.id):
                         await query.edit_message_text("❌ No tienes permisos de administrador.")
                         return
-                
+
                     if query.data == "admin_users":
                         await AdminHandlers._show_users_management(query)
-                    elif query.data == "admin_tokens":  # ← AÑADIR
+                    elif query.data == "admin_channels":
+                        await AdminHandlers._show_channels_management(query)
+                    elif query.data == "admin_tokens":
                         await AdminHandlers._show_tokens_management(query)
                     elif query.data == "admin_stats":
                         await AdminHandlers._show_stats(query)
-                    elif query.data == "admin_broadcast":  # ← AÑADIR
+                    elif query.data == "admin_broadcast":
                         await AdminHandlers._show_broadcast_menu(query)
-                    elif query.data == "admin_config":  # ← AÑADIR
+                    elif query.data == "admin_config":
                         await AdminHandlers._show_config_menu(query)
                     elif query.data == "admin_menu":
                         await AdminHandlers._show_admin_menu(query)
-                    elif query.data == "switch_to_user_view":  # ← MOVER AQUÍ
+                    elif query.data == "switch_to_user_view":
                         await AdminHandlers._switch_to_user_view(query)
                     else:
                         await query.edit_message_text(
                             "🚧 Función en desarrollo\n\n"
                             f"'{query.data}' estará disponible pronto.",
                             reply_markup=admin_keyboards.back_to_admin_keyboard()
-                            # ✅ SIN parse_mode para evitar errores
                         )
-        
-                elif query.data == "admin_channels":
-                    logger.info("📢 Redirigiendo a gestión de canales")
-                    from handlers.channel_handlers import ChannelHandlers
-                    await ChannelHandlers.channel_management_handler(update, context)
                 elif query.data in ["missions", "games", "story"]:
                         logger.info(f"🎮 Procesando: {query.data}")
                         await query.edit_message_text(

--- a/services/admin_commands.py
+++ b/services/admin_commands.py
@@ -5,22 +5,21 @@ from telegram import Update
 from telegram.ext import ContextTypes
 from core.database import get_db_session
 from services.channel_service import ChannelService
-from models.channel import ChannelType
+from models.channel import ChannelType, Channel
 import logging
 
 logger = logging.getLogger(__name__)
 
-
 class AdminCommands:
     """Comandos especiales para administradores"""
-
+    
     @staticmethod
     async def register_channel_command(update: Update, context: ContextTypes.DEFAULT_TYPE):
         """
         Comando: /register_channel <tipo> <id> <nombre>
         Ejemplo: /register_channel vip -1001234567890 Canal VIP Diana
         """
-        db = None  # Inicializar db como None
+        db = None
         
         try:
             logger.info(f"Argumentos recibidos: {context.args}")
@@ -28,13 +27,12 @@ class AdminCommands:
             if not context.args or len(context.args) < 3:
                 await update.message.reply_text(
                     "❌ Uso incorrecto\n\n"
-                    " **Formato:**\n"
+                    "📝 **Formato:**\n"
                     "`/register_channel <tipo> <id> <nombre>`\n\n"
-                    " **Ejemplos:**\n"
+                    "📋 **Ejemplos:**\n"
                     "`/register_channel vip -1001234567890 Canal VIP Diana`\n"
                     "`/register_channel free -1001234567891 Canal Gratuito Diana`\n\n"
-                    " **Tipos disponibles:** vip, free\n"
-                    " **ID del canal:** Debe ser un número (ej: -1001234567890)",
+                    "💡 **Tipos disponibles:** vip, free",
                     parse_mode="Markdown"
                 )
                 return
@@ -55,14 +53,14 @@ class AdminCommands:
             except ValueError:
                 await update.message.reply_text(
                     f"❌ ID de canal inválido: '{channel_id_str}'\n\n"
-                    f" **El ID debe ser un número entero**\n"
-                    f" **Ejemplos válidos:**\n"
+                    f"📝 **El ID debe ser un número entero**\n"
+                    f"📋 **Ejemplos válidos:**\n"
                     f"• `-1001234567890`\n"
-                    f"• `-1001111111111`\n"
-                    f"• `1234567890`\n\n"
-                    f" **Cómo obtener el ID:**\n"
+                    f"• `-1001111111111`\n\n"
+                    f"💡 **Cómo obtener el ID:**\n"
                     f"1. Añade @userinfobot al canal\n"
-                    f"2. El bot te dará el ID correcto"
+                    f"2. El bot te dará el ID correcto",
+                    parse_mode="Markdown"
                 )
                 return
             
@@ -76,36 +74,35 @@ class AdminCommands:
             logger.info("✅ Sesión de BD creada")
             
             try:
-                from models.channel import Channel
                 existing = db.query(Channel).filter(Channel.channel_id == channel_id).first()
                 
                 if existing:
                     await update.message.reply_text(
                         f"⚠️ **Canal ya registrado**\n\n"
-                        f" ID: `{channel_id}`\n"
-                        f" Nombre actual: {existing.channel_name}\n"
-                        f"️ Tipo actual: {existing.channel_type.value.upper()}\n\n"
-                        f" Usa un ID diferente o elimina el canal existente"
+                        f"📊 ID: `{channel_id}`\n"
+                        f"📝 Nombre actual: {existing.channel_name}\n"
+                        f"🏷️ Tipo actual: {existing.channel_type.value.upper()}\n\n"
+                        f"💡 Usa un ID diferente o elimina el canal existente",
+                        parse_mode="Markdown"
                     )
                     return
                 
                 channel = ChannelService.register_channel(db, channel_id, channel_name, channel_type)
                 logger.info(f"✅ Canal registrado exitosamente: {channel.id}")
                 
-                emoji = "" if channel_type == ChannelType.VIP else ""
+                emoji = "💎" if channel_type == ChannelType.VIP else "🆓"
                 await update.message.reply_text(
                     f"✅ **Canal Registrado Exitosamente**\n\n"
                     f"{emoji} **{channel_name}**\n"
-                    f" ID: `{channel_id}`\n"
-                    f"️ Tipo: {channel_type.value.upper()}\n"
-                    f" BD ID: {channel.id}\n\n"
-                    f" Usa /admin para gestionar tarifas y tokens",
+                    f"📊 ID: `{channel_id}`\n"
+                    f"🏷️ Tipo: {channel_type.value.upper()}\n\n"
+                    f"🎯 Usa /admin para gestionar tarifas y tokens",
                     parse_mode="Markdown"
                 )
                 
             except Exception as db_error:
                 logger.error(f"Error en operación de BD: {db_error}")
-                db.rollback()  # ROLLBACK EXPLÍCITO
+                db.rollback()
                 raise
                 
         except ValueError as e:
@@ -113,11 +110,9 @@ class AdminCommands:
             await update.message.reply_text(f"❌ Error de validación: {str(e)}")
         except Exception as e:
             logger.error(f"Error en register_channel_command: {e}")
-            logger.error(f"Argumentos que causaron el error: {context.args}")
             await update.message.reply_text(
                 f"❌ Error interno registrando canal\n"
-                f" Detalles: {str(e)}\n\n"
-                f" Verifica el formato del comando"
+                f"🔍 Detalles: {str(e)}"
             )
         finally:
             if db:
@@ -126,6 +121,37 @@ class AdminCommands:
                     logger.info("✅ Sesión de BD cerrada")
                 except Exception as close_error:
                     logger.error(f"Error cerrando sesión BD: {close_error}")
+
+    @staticmethod
+    async def list_channels_command(update: Update, context: ContextTypes.DEFAULT_TYPE):
+        """Comando: /list_channels"""
+        try:
+            db = get_db_session()
+            try:
+                channels = ChannelService.get_channels(db)
+                
+                if not channels:
+                    await update.message.reply_text("📋 No hay canales registrados")
+                    return
+                
+                text = "📋 **Canales Registrados**\n\n"
+                
+                for channel in channels:
+                    emoji = "💎" if channel.channel_type == ChannelType.VIP else "🆓"
+                    status = "🟢" if channel.is_active else "🔴"
+                    
+                    text += f"{emoji} {status} **{channel.channel_name}**\n"
+                    text += f"   📊 ID: `{channel.channel_id}`\n"
+                    text += f"   🏷️ Tipo: {channel.channel_type.value.upper()}\n\n"
+                
+                await update.message.reply_text(text, parse_mode="Markdown")
+                
+            finally:
+                db.close()
+                
+        except Exception as e:
+            logger.error(f"Error en list_channels_command: {e}")
+            await update.message.reply_text("❌ Error obteniendo canales")
 
     @staticmethod
     async def clear_channels_command(update: Update, context: ContextTypes.DEFAULT_TYPE):
@@ -139,8 +165,8 @@ class AdminCommands:
                 db.commit()
                 
                 await update.message.reply_text(
-                    f"️ **Canales eliminados**\n\n"
-                    f" Canales eliminados: {count}\n"
+                    f"🗑️ **Canales eliminados**\n\n"
+                    f"📊 Canales eliminados: {count}\n"
                     f"✅ Base de datos limpia"
                 )
             finally:
@@ -149,34 +175,3 @@ class AdminCommands:
         except Exception as e:
             logger.error(f"Error limpiando canales: {e}")
             await update.message.reply_text(f"❌ Error: {e}")
-
-    @staticmethod
-    async def list_channels_command(update: Update, context: ContextTypes.DEFAULT_TYPE):
-        """Comando: /list_channels"""
-        try:
-            db = get_db_session()
-            try:
-                channels = ChannelService.get_channels(db)
-
-                if not channels:
-                    await update.message.reply_text("📋 No hay canales registrados")
-                    return
-
-                text = "📋 **Canales Registrados**\n\n"
-
-                for channel in channels:
-                    emoji = "💎" if channel.channel_type == ChannelType.VIP else "🆓"
-                    status = "🟢" if channel.is_active else "🔴"
-
-                    text += f"{emoji} {status} **{channel.channel_name}**\n"
-                    text += f"   📊 ID: `{channel.channel_id}`\n"
-                    text += f"   🏷️ Tipo: {channel.channel_type.value.upper()}\n\n"
-
-                await update.message.reply_text(text, parse_mode="Markdown")
-
-            finally:
-                db.close()
-
-        except Exception as e:
-            logger.error(f"Error en list_channels_command: {e}")
-            await update.message.reply_text("❌ Error obteniendo canales")


### PR DESCRIPTION
## Summary
- route admin channel management via `AdminHandlers._show_channels_management`
- handle `admin_channels` callbacks inside the admin block
- provide special admin commands for channel registration and listing

## Testing
- `python -m py_compile handlers/admin_handlers.py handlers/channel_handlers.py handlers/base_handlers.py services/admin_commands.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6869d14723ec8329882df209c1873524