### PR TITLE
Add aiogram bot entrypoint

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -1,0 +1,52 @@
+import asyncio
+import logging
+
+from aiogram import Bot, Dispatcher
+from aiogram.fsm.storage.memory import MemoryStorage
+
+from config import BOT_TOKEN
+
+from handlers.onboarding import router as onboarding_router
+from handlers.backpack import router as backpack_router
+from handlers.combination import router as combination_router
+from handlers.vip_access import router as vip_access_router
+from handlers.gamification import router as gamification_router
+from handlers.notifications import router as notifications_router
+from handlers.channel_access import router as channel_access_router
+
+from middlewares.logging import LoggingMiddleware
+from middlewares.auth import AdminAuthMiddleware
+from middlewares.vip_middleware import VIPMiddleware
+from middlewares.narrative_middleware import NarrativeContextMiddleware
+from utils.middlewares import error_handler
+from utils.scheduler import run_scheduler
+
+
+async def main() -> None:
+    logging.basicConfig(level=logging.INFO)
+
+    bot = Bot(BOT_TOKEN)
+    storage = MemoryStorage()
+    dp = Dispatcher(storage=storage)
+
+    dp.message.middleware(error_handler)
+    dp.message.middleware(LoggingMiddleware())
+    dp.message.middleware(NarrativeContextMiddleware())
+    dp.message.middleware(AdminAuthMiddleware())
+    dp.message.middleware(VIPMiddleware())
+
+    dp.include_router(onboarding_router)
+    dp.include_router(backpack_router)
+    dp.include_router(combination_router)
+    dp.include_router(vip_access_router)
+    dp.include_router(gamification_router)
+    dp.include_router(notifications_router)
+    dp.include_router(channel_access_router)
+
+    asyncio.create_task(run_scheduler(bot))
+
+    await dp.start_polling(bot)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/middlewares/narrative_middleware.py
+++ b/middlewares/narrative_middleware.py
@@ -1,5 +1,11 @@
+from typing import Any, Callable, Dict, Awaitable
 
-from typing import Optional
+from aiogram import BaseMiddleware
 
-# Placeholder for narrative middleware implementation
 
+class NarrativeContextMiddleware(BaseMiddleware):
+    """Attach a simple narrative context to handler data."""
+
+    async def __call__(self, handler: Callable[[Any, Dict[str, Any]], Awaitable[Any]], event: Any, data: Dict[str, Any]) -> Any:
+        data.setdefault("narrative_context", {})
+        return await handler(event, data)

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ python-dotenv==1.0.0
 apscheduler==3.10.4
 psycopg2-binary==2.9.7
 aiosqlite==0.19.0  # ← Esta línea resuelve el problema
+aiogram==3.4.1

--- a/services/narrative_event_scheduler.py
+++ b/services/narrative_event_scheduler.py
@@ -1,0 +1,12 @@
+import asyncio
+import logging
+from aiogram import Bot
+
+logger = logging.getLogger(__name__)
+
+
+async def start(bot: Bot) -> None:
+    """Placeholder scheduler for narrative events."""
+    while True:
+        logger.debug("Narrative scheduler tick")
+        await asyncio.sleep(3600)


### PR DESCRIPTION
## Summary
- create `bot.py` to run aiogram with routers and middleware
- add simple `NarrativeContextMiddleware`
- include placeholder `narrative_event_scheduler`
- add aiogram to requirements

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686af9f4c98c83299b82d147dc492bb0